### PR TITLE
Add extension for Subject

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except Exception:
 
 setup_args = {
     "name": "ndx-pinto-metadata",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "The NWB extension for storing ViRMEN experimental metadata for the Pinto lab.",
     "long_description": readme,
     "long_description_content_type": readme_type,

--- a/spec/ndx-pinto-metadata.extensions.yaml
+++ b/spec/ndx-pinto-metadata.extensions.yaml
@@ -62,6 +62,8 @@ groups:
   - name: zygosity
     dtype: text
     doc: The zygosity of the subject.
+    required: false
   - name: ear_tag_id
     dtype: text
     doc: The text identification of the ear tag.
+    required: false

--- a/spec/ndx-pinto-metadata.extensions.yaml
+++ b/spec/ndx-pinto-metadata.extensions.yaml
@@ -55,3 +55,13 @@ groups:
 - neurodata_type_def: MazeExtension
   neurodata_type_inc: DynamicTable
   doc: type for storing maze information
+- neurodata_type_def: SubjectExtension
+  neurodata_type_inc: Subject
+  doc: type for subject metadata for Pinto lab
+  attributes:
+  - name: zygosity
+    dtype: text
+    doc: The zygosity of the subject.
+  - name: ear_tag_id
+    dtype: text
+    doc: The text identification of the ear tag.

--- a/spec/ndx-pinto-metadata.namespace.yaml
+++ b/spec/ndx-pinto-metadata.namespace.yaml
@@ -11,5 +11,6 @@ namespaces:
     neurodata_types:
     - LabMetaData
     - DynamicTable
+    - Subject
   - source: ndx-pinto-metadata.extensions.yaml
-  version: 0.1.1
+  version: 0.1.2

--- a/src/pynwb/ndx_pinto_metadata/__init__.py
+++ b/src/pynwb/ndx_pinto_metadata/__init__.py
@@ -2,3 +2,4 @@ from pynwb import get_class
 from .maze_extension import MazeExtension
 
 LabMetaDataExtension = get_class("LabMetaDataExtension", "ndx-pinto-metadata")
+SubjectExtension = get_class("SubjectExtension", "ndx-pinto-metadata")

--- a/src/pynwb/tests/test_subject_extension.py
+++ b/src/pynwb/tests/test_subject_extension.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from uuid import uuid4
+
+from dateutil.tz import tzlocal
+from hdmf.testing import TestCase, remove_test_file
+from pynwb import NWBHDF5IO, NWBFile
+
+from ndx_pinto_metadata import SubjectExtension
+
+
+class TestLabMetaDataExtensionConstructor(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier=str(uuid4()),
+            session_start_time=datetime(1970, 1, 1, tzinfo=tzlocal()),
+        )
+
+        cls.subject_metadata = dict(
+            ear_tag_id="13005",
+            zygosity="Homozygous",
+            age="P7D",
+            genotype="ChAT-Ai96",
+            sex="M",
+            species="Mus musculus",
+            subject_id="DrChicken",
+        )
+
+        cls.nwbfile_path = "test.nwb"
+
+    @classmethod
+    def tearDownClass(cls):
+        remove_test_file(cls.nwbfile_path)
+
+    def test_constructor(self):
+        self.nwbfile.subject = SubjectExtension(**self.subject_metadata)
+
+        self.assertEqual(
+            self.nwbfile.subject.ear_tag_id, self.subject_metadata["ear_tag_id"]
+        )
+        self.assertEqual(
+            self.nwbfile.subject.zygosity, self.subject_metadata["zygosity"]
+        )
+
+    def test_roundtrip(self):
+        with NWBHDF5IO(self.nwbfile_path, mode="w") as io:
+            io.write(self.nwbfile)
+
+        with NWBHDF5IO(self.nwbfile_path, mode="r", load_namespaces=True) as io:
+            read_nwbfile = io.read()
+            self.assertIsInstance(read_nwbfile.subject, SubjectExtension)
+            self.assertContainerEqual(
+                read_nwbfile.subject,
+                self.nwbfile.subject,
+            )

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -120,11 +120,13 @@ def main():
         name="zygosity",
         doc="The zygosity of the subject.",
         dtype="text",
+        required=False,
     )
     subject_extension.add_attribute(
         name="ear_tag_id",
         doc="The text identification of the ear tag.",
         dtype="text",
+        required=False,
     )
 
     new_data_types = [

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -8,13 +8,14 @@ def main():
     ns_builder = NWBNamespaceBuilder(
         doc="type for storing metadata for Pinto lab",
         name="ndx-pinto-metadata",
-        version="0.1.1",
+        version="0.1.2",
         author=["Szonja Weigl", "Ben Dichter"],
         contact=["ben.dichter@catalystneuro.com"],
     )
 
     ns_builder.include_type("LabMetaData", namespace="core")
     ns_builder.include_type("DynamicTable", namespace="core")
+    ns_builder.include_type("Subject", namespace="core")
 
     lab_meta_data_extension = NWBGroupSpec(
         doc="type for storing metadata for Pinto lab",
@@ -110,9 +111,26 @@ def main():
         quantity="?",
     )
 
+    subject_extension = NWBGroupSpec(
+        doc="type for subject metadata for Pinto lab",
+        neurodata_type_def="SubjectExtension",
+        neurodata_type_inc="Subject",
+    )
+    subject_extension.add_attribute(
+        name="zygosity",
+        doc="The zygosity of the subject.",
+        dtype="text",
+    )
+    subject_extension.add_attribute(
+        name="ear_tag_id",
+        doc="The text identification of the ear tag.",
+        dtype="text",
+    )
+
     new_data_types = [
         lab_meta_data_extension,
         maze_extension,
+        subject_extension,
     ]
 
     # export the spec to yaml files in the spec folder

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -112,7 +112,7 @@ def main():
     )
 
     subject_extension = NWBGroupSpec(
-        doc="type for subject metadata for Pinto lab",
+        doc="Extended subject tpye for metadata specific to the Pinto lab.",
         neurodata_type_def="SubjectExtension",
         neurodata_type_inc="Subject",
     )


### PR DESCRIPTION
Extends `Subject` to store `zygosity` and `ear_tag_id` for the experimental subject:

<img width="618" alt="Screenshot 2023-12-01 at 15 57 04 (2)" src="https://github.com/catalystneuro/ndx-pinto-metadata/assets/24475788/0ef11f0f-f2bf-40f4-8abe-222f7f5fa629">
